### PR TITLE
Improve MCP streaming synthesis documentation and fix defaults

### DIFF
--- a/.changeset/mcp-streaming-docs.md
+++ b/.changeset/mcp-streaming-docs.md
@@ -1,0 +1,8 @@
+---
+"@kajidog/aivis-cloud-cli": patch
+---
+
+Improve MCP documentation and default behavior:
+- Add streaming audio synthesis documentation for MCP tools
+- Fix MCP default playback mode to 'immediate' when not configured  
+- Update README with streaming synthesis details for synthesize_speech tool

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm で配布される CLI ツール。**機能詳細・使用例・MCP設定は
 # 例1: テキストから音声ファイルを生成
 npx @kajidog/aivis-cloud-cli tts synthesize --text "こんにちは世界" --output "output.wav"
 
-# 例2: Claude CodeにMCPを登録
+# 例2: Claude CodeにMCPを登録（AIアシスタントがストリーミング音声合成・即座再生可能）
 claude mcp add aivis npx @kajidog/aivis-cloud-cli mcp
 ```
 

--- a/packages/cli/mcp_tools_tts.go
+++ b/packages/cli/mcp_tools_tts.go
@@ -120,20 +120,23 @@ func handleSynthesizeSpeech(ctx context.Context, req *mcp.CallToolRequest, args 
 	// Create playback request with options
 	playbackReq := aivisClient.NewPlaybackRequest(request.Build())
 	
-	// Set playback mode
+	// Set playback mode (default to immediate for MCP)
 	playbackMode := args.PlaybackMode
 	if playbackMode == "" {
 		playbackMode = viper.GetString("default_playback_mode")
-	}
-	if playbackMode != "" {
-		switch playbackMode {
-		case "immediate":
-			playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeImmediate)
-		case "queue":
-			playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeQueue)
-		case "no_queue":
-			playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeNoQueue)
+		if playbackMode == "" {
+			playbackMode = "immediate" // MCP default
 		}
+	}
+	switch playbackMode {
+	case "immediate":
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeImmediate)
+	case "queue":
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeQueue)
+	case "no_queue":
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeNoQueue)
+	default:
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeImmediate) // fallback
 	}
 	
 	// Set wait for end flag
@@ -253,20 +256,23 @@ func handlePlayText(ctx context.Context, req *mcp.CallToolRequest, args PlayText
 	// Create playback request with options
 	playbackReq := aivisClient.NewPlaybackRequest(request.Build())
 	
-	// Set playback mode
+	// Set playback mode (default to immediate for MCP)
 	playbackMode := args.PlaybackMode
 	if playbackMode == "" {
 		playbackMode = viper.GetString("default_playback_mode")
-	}
-	if playbackMode != "" {
-		switch playbackMode {
-		case "immediate":
-			playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeImmediate)
-		case "queue":
-			playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeQueue)
-		case "no_queue":
-			playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeNoQueue)
+		if playbackMode == "" {
+			playbackMode = "immediate" // MCP default
 		}
+	}
+	switch playbackMode {
+	case "immediate":
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeImmediate)
+	case "queue":
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeQueue)
+	case "no_queue":
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeNoQueue)
+	default:
+		playbackReq = playbackReq.WithMode(ttsDomain.PlaybackModeImmediate) // fallback
 	}
 	
 	// Set wait for end flag

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -301,9 +301,11 @@ MCP サーバーは以下のツールを AI アシスタントに提供します
 
 - **synthesize_speech**: テキストを音声に変換してサーバー上で再生（フル機能版）
 
+  - **ストリーミング音声合成**: 音声生成と同時に再生開始（~500ms遅延）
+  - **プログレッシブ再生**: 最初の音声チャンクが到着次第、即座に再生開始
   - パラメータ: `text` (必須), `model_uuid`, `format`, `volume`, `rate`, `pitch`, `playback_mode`, `wait_for_end`
   - 音声フォーマット: `wav`, `mp3`, `flac`, `aac`, `opus`
-  - 再生モード: `immediate` (即座再生), `queue` (キュー追加), `no_queue` (同時再生)
+  - 再生モード: `immediate` (即座再生, デフォルト), `queue` (キュー追加), `no_queue` (同時再生)
 
 - **play_text**: デフォルト設定でテキストを音声再生（簡易版）
   - パラメータ: `text` (必須), `playback_mode`, `wait_for_end`


### PR DESCRIPTION
Enhance documentation for MCP streaming audio synthesis and update default playback mode to 'immediate' when not specified. Update README with relevant details for the synthesize_speech tool.