### PR TITLE
Change default audio format to MP3 and enhance playback characteristics

### DIFF
--- a/.changeset/default-format-mp3-and-mcp-flags.md
+++ b/.changeset/default-format-mp3-and-mcp-flags.md
@@ -1,5 +1,5 @@
 ---
-"@kajidog/aivis-cloud-cli": minor
+"@kajidog/aivis-cloud-cli": patch
 ---
 
 feat: change default audio format to mp3 and expose authoritative playback characteristics in MCP responses.

--- a/.changeset/default-format-mp3-and-mcp-flags.md
+++ b/.changeset/default-format-mp3-and-mcp-flags.md
@@ -1,0 +1,10 @@
+---
+"@kajidog/aivis-cloud-cli": minor
+---
+
+feat: change default audio format to mp3 and expose authoritative playback characteristics in MCP responses.
+
+- Default format: switch from wav to mp3 across CLI/client defaults and examples.
+- MCP (tts/history): include playback mode and streaming flags using client‑computed values (no guessing in MCP layer).
+- Client: add `streaming_synthesis`, `streaming_playback`, and `effective_mode` to TTS response; expose `DetectStreamingPlayback()` and compute values based on OS/player/format.
+- Docs: update configuration table and examples to reflect mp3 as default.

--- a/.changeset/mcp-history-playback-fixes.md
+++ b/.changeset/mcp-history-playback-fixes.md
@@ -1,0 +1,10 @@
+---
+"@kajidog/aivis-cloud-cli": patch
+---
+
+fix(mcp): improve history playback reliability and path handling.
+
+- Enforce `no_queue` mode for MCP `play_tts_history`, and let `wait_for_end` follow the request argument.
+- Expand `history_store_path` (`~` and env vars) in MCP tools and client config; ensure absolute path usage.
+- Reduce zero-byte history records by waiting until the history file has non-zero size before saving metadata.
+- Propagate history settings (`history_enabled`, `history_max_count`, `history_store_path`) from config into the client.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,12 @@ jobs:
             
             ### Direct binary download
             Download the appropriate binary for your platform from the assets below and add it to your PATH.
-          files: packages/npm/binaries/*/*
+          files: |
+            packages/npm/binaries/linux-amd64/aivis-cli
+            packages/npm/binaries/linux-arm64/aivis-cli
+            packages/npm/binaries/darwin-amd64/aivis-cli
+            packages/npm/binaries/darwin-arm64/aivis-cli
+            packages/npm/binaries/windows-amd64/aivis-cli.exe
+            packages/npm/binaries/windows-arm64/aivis-cli.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm で配布される CLI ツール。**機能詳細・使用例・MCP設定は
 使用例:
 ```bash
 # 例1: テキストから音声ファイルを生成（履歴自動保存）
-npx @kajidog/aivis-cloud-cli tts synthesize --text "こんにちは世界" --output "output.wav"
+npx @kajidog/aivis-cloud-cli tts synthesize --text "こんにちは世界" --output "output.mp3"
 
 # 例2: TTS履歴の管理・再生
 npx @kajidog/aivis-cloud-cli tts history list    # 履歴一覧表示

--- a/packages/cli/config.go
+++ b/packages/cli/config.go
@@ -83,7 +83,7 @@ func getConfigSpecs() []ConfigSpec {
         {Key: "timeout", Type: "duration", Description: "HTTP timeout (e.g. 60s)", Validate: parseDuration},
         {Key: "default_playback_mode", Type: "enum", Description: "Playback mode (immediate|queue|no_queue)", Validate: parseEnum("immediate", "queue", "no_queue")},
         {Key: "default_model_uuid", Type: "string", Description: "Default voice model UUID", Validate: func(s string) (any, error) { return s, nil }},
-        {Key: "default_format", Type: "enum", Description: "Default audio format (wav|mp3|flac|aac|opus)", Validate: parseEnum("wav", "mp3", "flac", "aac", "opus")},
+        {Key: "default_format", Type: "enum", Description: "Default audio format (mp3|wav|flac|aac|opus)", Validate: parseEnum("wav", "mp3", "flac", "aac", "opus")},
         {Key: "default_channels", Type: "enum", Description: "Audio channels (mono|stereo)", Validate: parseEnum("mono", "stereo")},
         {Key: "default_volume", Type: "number", Description: "Default TTS volume (0.0..2.0)", Validate: parseFloatInRange(0.0, 2.0)},
         {Key: "default_rate", Type: "number", Description: "Default speaking rate (0.5..2.0)", Validate: parseFloatInRange(0.5, 2.0)},
@@ -258,9 +258,9 @@ var configInitCmd = &cobra.Command{
 		if !viper.IsSet("default_model_uuid") {
 			viper.Set("default_model_uuid", "")
 		}
-		if !viper.IsSet("default_format") {
-			viper.Set("default_format", "wav")
-		}
+        if !viper.IsSet("default_format") {
+            viper.Set("default_format", "mp3")
+        }
 		if !viper.IsSet("default_volume") {
 			viper.Set("default_volume", 1.0)
 		}

--- a/packages/cli/main.go
+++ b/packages/cli/main.go
@@ -84,7 +84,7 @@ func initializeClient() error {
 		return fmt.Errorf("API key is required. Set it via --api-key flag, AIVIS_API_KEY environment variable, or config file")
 	}
 
-	cfg := config.NewConfig(apiKey)
+    cfg := config.NewConfig(apiKey)
 	if baseURL := viper.GetString("base_url"); baseURL != "" {
 		cfg.BaseURL = baseURL
 	}
@@ -113,7 +113,20 @@ func initializeClient() error {
 		cfg.LogFormat = configLogFormat
 	}
 
-	// For MCP stdio mode, force log output to stderr to avoid protocol contamination
+    // History settings
+    if viper.IsSet("history_enabled") {
+        cfg.HistoryEnabled = viper.GetBool("history_enabled")
+    }
+    if viper.IsSet("history_max_count") {
+        if v := viper.GetInt("history_max_count"); v > 0 {
+            cfg.HistoryMaxCount = v
+        }
+    }
+    if v := viper.GetString("history_store_path"); v != "" {
+        cfg.HistoryStorePath = v
+    }
+
+    // For MCP stdio mode, force log output to stderr to avoid protocol contamination
 	if isMCPStdioMode() {
 		cfg.LogOutput = "stderr"
 	}

--- a/packages/cli/mcp_tools_history.go
+++ b/packages/cli/mcp_tools_history.go
@@ -348,10 +348,14 @@ func handlePlayTTSHistory(ctx context.Context, req *mcp.CallToolRequest, args Pl
 	result.WriteString(fmt.Sprintf("Model: %s\n", history.ModelUUID))
 	result.WriteString(fmt.Sprintf("Format: %s (%s)\n", history.FileFormat, formatFileSize(history.FileSizeBytes)))
 	
-	if args.Volume > 0 {
-		result.WriteString(fmt.Sprintf("Volume: %.2f\n", args.Volume))
-	}
-	result.WriteString(fmt.Sprintf("Playback Mode: %s\n", playbackMode))
+    if args.Volume > 0 {
+        result.WriteString(fmt.Sprintf("Volume: %.2f\n", args.Volume))
+    }
+    result.WriteString(fmt.Sprintf("Playback Mode: %s\n", playbackMode))
+    // Detect accurate streaming playback capability via client logic
+    sp := aivisClient.DetectStreamingPlayback(ttsDomain.OutputFormat(history.FileFormat))
+    result.WriteString("Streaming Synthesis: false\n")
+    result.WriteString(fmt.Sprintf("Streaming Playback: %t\n", sp))
 	
 	if args.WaitForEnd {
 		result.WriteString("\nWaiting for playback completion...")
@@ -457,4 +461,3 @@ func handleGetTTSHistoryStats(ctx context.Context, req *mcp.CallToolRequest, arg
 		Content: []mcp.Content{&mcp.TextContent{Text: result.String()}},
 	}, nil, nil
 }
-

--- a/packages/cli/mcp_tools_tts.go
+++ b/packages/cli/mcp_tools_tts.go
@@ -10,6 +10,7 @@ import (
 	ttsDomain "github.com/kajidog/aivis-cloud-cli/client/tts/domain"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 // SynthesizeSpeechParams parameters for synthesize_speech tool
@@ -194,6 +195,15 @@ func handleSynthesizeSpeech(ctx context.Context, req *mcp.CallToolRequest, args 
 	
 	// Get history directory from config or use default
 	historyDir := viper.GetString("history_store_path")
+	// Expand ~ and env vars for robustness
+	if historyDir != "" {
+		if strings.HasPrefix(historyDir, "~") {
+			if home, err := os.UserHomeDir(); err == nil {
+				historyDir = filepath.Join(home, strings.TrimPrefix(historyDir, "~"))
+			}
+		}
+		historyDir = os.ExpandEnv(historyDir)
+	}
 	if historyDir == "" {
 		homeDir, _ := os.UserHomeDir()
 		historyDir = filepath.Join(homeDir, ".aivis-cli", "history", "audio")
@@ -380,6 +390,15 @@ func handlePlayText(ctx context.Context, req *mcp.CallToolRequest, args PlayText
 	
 	// Get history directory from config or use default
 	historyDir := viper.GetString("history_store_path")
+	// Expand ~ and env vars for robustness
+	if historyDir != "" {
+		if strings.HasPrefix(historyDir, "~") {
+			if home, err := os.UserHomeDir(); err == nil {
+				historyDir = filepath.Join(home, strings.TrimPrefix(historyDir, "~"))
+			}
+		}
+		historyDir = os.ExpandEnv(historyDir)
+	}
 	if historyDir == "" {
 		homeDir, _ := os.UserHomeDir()
 		historyDir = filepath.Join(homeDir, ".aivis-cli", "history", "audio")

--- a/packages/cli/tts_history.go
+++ b/packages/cli/tts_history.go
@@ -72,8 +72,14 @@ var ttsHistoryListCmd = &cobra.Command{
 				model = model[:8] + "..."
 			}
 			
-			// Format file size
-			size := formatFileSize(history.FileSizeBytes)
+            // Format file size (prefer actual file size if available)
+            sizeBytes := history.FileSizeBytes
+            if history.FilePath != "" {
+                if fi, err := os.Stat(history.FilePath); err == nil {
+                    sizeBytes = fi.Size()
+                }
+            }
+            size := formatFileSize(sizeBytes)
 			
 			// Format creation time
 			created := history.CreatedAt.Format("01/02 15:04")
@@ -128,7 +134,14 @@ var ttsHistoryShowCmd = &cobra.Command{
 		fmt.Printf("Created: %s\n", history.CreatedAt.Format("2006-01-02 15:04:05"))
 		fmt.Printf("File Path: %s\n", history.FilePath)
 		fmt.Printf("File Format: %s\n", history.FileFormat)
-		fmt.Printf("File Size: %s\n", formatFileSize(history.FileSizeBytes))
+        // Prefer actual file size if available
+        sizeBytes := history.FileSizeBytes
+        if history.FilePath != "" {
+            if fi, err := os.Stat(history.FilePath); err == nil {
+                sizeBytes = fi.Size()
+            }
+        }
+        fmt.Printf("File Size: %s\n", formatFileSize(sizeBytes))
 		
 		if history.Credits != nil {
 			fmt.Printf("Credits Used: %.4f\n", *history.Credits)

--- a/packages/client/client.go
+++ b/packages/client/client.go
@@ -452,11 +452,11 @@ func (c *Client) PlayStreamWithHistory(ctx context.Context, request *ttsDomain.P
         return nil, fmt.Errorf("streaming synthesis and playback failed: %w", err)
     }
 
-    // Best-effort: wait briefly until the history file is created by the streaming goroutine
-    // to avoid race where SaveHistory fails with file-not-found
+    // Best-effort: wait briefly until the history file is created and has non-zero size
+    // to avoid race where SaveHistory sees a zero-byte file
     waitDeadline := time.Now().Add(3 * time.Second)
     for time.Now().Before(waitDeadline) {
-        if _, statErr := os.Stat(filePath); statErr == nil {
+        if fi, statErr := os.Stat(filePath); statErr == nil && fi.Size() > 0 {
             break
         }
         select {

--- a/packages/client/config/config.go
+++ b/packages/client/config/config.go
@@ -131,7 +131,23 @@ func (c *Config) WithHistoryStorePath(path string) *Config {
 // GetHistoryStorePath returns the full path for history storage
 func (c *Config) GetHistoryStorePath() (string, error) {
 	if c.HistoryStorePath != "" {
-		return c.HistoryStorePath, nil
+		p := c.HistoryStorePath
+		// Expand environment variables
+		p = os.ExpandEnv(p)
+		// Expand leading ~ to user home
+		if strings.HasPrefix(p, "~") {
+			homeDir, err := os.UserHomeDir()
+			if err == nil {
+				p = filepath.Join(homeDir, strings.TrimPrefix(p, "~"))
+			}
+		}
+		// Make absolute if necessary
+		if !filepath.IsAbs(p) {
+			if abs, err := filepath.Abs(p); err == nil {
+				p = abs
+			}
+		}
+		return p, nil
 	}
 	
 	// Use default user home directory

--- a/packages/client/tts/domain/model.go
+++ b/packages/client/tts/domain/model.go
@@ -70,10 +70,14 @@ type TTSRequest struct {
 
 // TTSResponse represents a text-to-speech synthesis response
 type TTSResponse struct {
-	AudioData   io.ReadCloser     `json:"-"`
-	BillingInfo *http.BillingInfo `json:"billing_info,omitempty"`
-	FileName    string            `json:"filename,omitempty"`
-	HistoryID   int               `json:"history_id,omitempty"` // Sequential ID for history management
+    AudioData   io.ReadCloser     `json:"-"`
+    BillingInfo *http.BillingInfo `json:"billing_info,omitempty"`
+    FileName    string            `json:"filename,omitempty"`
+    HistoryID   int               `json:"history_id,omitempty"` // Sequential ID for history management
+    // Playback characteristics (authoritative, computed by client)
+    StreamingSynthesis bool          `json:"streaming_synthesis,omitempty"`
+    StreamingPlayback  bool          `json:"streaming_playback,omitempty"`
+    EffectiveMode      *PlaybackMode `json:"effective_mode,omitempty"`
 }
 
 // TTSStreamChunk represents a chunk of streaming audio data

--- a/packages/client/tts/usecase/adapter.go
+++ b/packages/client/tts/usecase/adapter.go
@@ -71,10 +71,10 @@ func (a *AudioPlayerServiceAdapter) GetGlobalService() *GlobalAudioPlayerService
 
 // getOutputFormatFromRequest extracts output format from playback request
 func getOutputFormatFromRequest(request *domain.PlaybackRequest) domain.OutputFormat {
-	if request.TTSRequest != nil && request.TTSRequest.OutputFormat != nil {
-		return *request.TTSRequest.OutputFormat
-	}
-	return domain.OutputFormatWAV // default
+    if request.TTSRequest != nil && request.TTSRequest.OutputFormat != nil {
+        return *request.TTSRequest.OutputFormat
+    }
+    return domain.OutputFormatMP3 // default
 }
 
 // Stop stops current playback and clears queue

--- a/packages/client/tts/usecase/global_player.go
+++ b/packages/client/tts/usecase/global_player.go
@@ -739,7 +739,7 @@ func (s *GlobalAudioPlayerService) synthesizeAndPlayStreamSyncWithHistory(ctx co
 // Helper functions
 
 func getOutputFormat(request *domain.PlaybackRequest) domain.OutputFormat {
-	format := domain.OutputFormatWAV // default
+    format := domain.OutputFormatMP3 // default
 	if request.TTSRequest.OutputFormat != nil {
 		format = *request.TTSRequest.OutputFormat
 	}

--- a/packages/client/tts/usecase/player.go
+++ b/packages/client/tts/usecase/player.go
@@ -260,7 +260,7 @@ func (s *AudioPlayerService) synthesizeAndPlay(ctx context.Context, request *dom
 	}
 	
 	// Determine output format
-	format := domain.OutputFormatWAV // default
+    format := domain.OutputFormatMP3 // default
 	if request.TTSRequest.OutputFormat != nil {
 		format = *request.TTSRequest.OutputFormat
 	}

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -142,15 +142,15 @@ npx @kajidog/aivis-cloud-cli tts synthesize "こんにちは世界"
 # 履歴一覧表示
 npx @kajidog/aivis-cloud-cli tts history list
 # ID  Text          Model     Format  Size    Created
-# 1   こんにちは世界  a59cb...  wav     45KB    01/01 12:00
+# 1   こんにちは世界  a59cb...  mp3     45KB    01/01 12:00
 
 # 履歴詳細表示（リクエスト内容、ファイル情報など）
 npx @kajidog/aivis-cloud-cli tts history show 1
 # Text: こんにちは世界
 # Model UUID: a59cb814-0083-4369-8542-f51a29e72af7
 # Created: 2025-01-01 12:00:00
-# File Path: tts_20250101_120000.wav
-# File Format: wav
+# File Path: tts_20250101_120000.mp3
+# File Format: mp3
 # File Size: 45.2 KB
 # Credits Used: 0.0050
 # 
@@ -596,7 +596,7 @@ ffplay -version
 | `timeout`                  | string  | `60s`                           | HTTP リクエストのタイムアウト              |
 | `default_playback_mode`    | string  | `immediate`                     | デフォルトの音声再生モード                 |
 | `default_model_uuid`       | string  | -                               | デフォルト音声モデル UUID                  |
-| `default_format`           | string  | `wav`                           | デフォルト音声フォーマット                 |
+| `default_format`           | string  | `mp3`                           | デフォルト音声フォーマット                 |
 | `default_volume`           | float64 | `1.0`                           | デフォルト音量（0.0-2.0）                  |
 | `default_rate`             | float64 | `1.0`                           | デフォルト再生速度（0.5-2.0）              |
 | `default_pitch`            | float64 | `0.0`                           | デフォルトピッチ（-1.0 から 1.0）          |
@@ -661,7 +661,7 @@ base_url: "https://api.aivis-project.com"
 timeout: "60s"
 default_playback_mode: "immediate"
 default_model_uuid: "a59cb814-0083-4369-8542-f51a29e72af7"
-default_format: "wav"
+default_format: "mp3"
 default_volume: 1.0
 default_rate: 1.0
 default_pitch: 0.0

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -4,6 +4,16 @@ Aivis Cloud API を使用して音声合成と音声再生を行うコマンド�
 
 **公式サイト**: https://aivis-project.com/
 
+## 目次
+
+- クイックスタート（CLI / MCP）
+- 再生ポリシー（共通の考え方）
+- CLI コマンド概要
+- MCP ツール概要
+- 設定（よく使う項目 / 一覧 / 優先度）
+- トラブルシュート（再生できない/0バイト/ffplay）
+- FFplay の導入（任意・推奨）
+
 ## このパッケージでできること
 
 - **音声合成（TTS）**: テキストを自然な音声に変換
@@ -48,7 +58,54 @@ Aivis Cloud API キーが必要です。
 2. コマンドフラグ: `--api-key "your-api-key"`
 3. 設定ファイル: `aivis-cloud-cli config set api_key "your-api-key"`
 
-## 基本的な使い方
+## クイックスタート
+
+### CLI（最短手順）
+
+```bash
+# インストール不要
+npx @kajidog/aivis-cloud-cli tts play --text "こんにちは世界"
+# 履歴から再生
+npx @kajidog/aivis-cloud-cli tts history play 1
+```
+
+### MCP（最短手順）
+
+```bash
+# Claude などに MCP サーバーを追加
+claude mcp add aivis "npx @kajidog/aivis-cloud-cli mcp"
+
+# ツール呼び出し（例）
+# synthesize_speech: text / playback_mode / wait_for_end などを渡す
+```
+
+## CLI コマンド概要
+
+- `tts synthesize`: テキスト→音声ファイル保存（履歴自動保存）
+- `tts play`: テキストを即時再生（既定で履歴保存）
+- `tts history`: 履歴の一覧/詳細/再生/削除/統計
+- `config`: API キーやデフォルト値の設定/表示
+- `models`: モデルの検索/取得
+- `mcp`: MCP サーバー起動（stdio/http）
+
+詳細な例は「基本的な使い方（詳細）」を参照。
+
+## MCP ツール概要
+
+- 合成/再生系: `synthesize_speech`（または簡略モード時 `play_text`）
+  - 主な引数: `text`, `playback_mode`, `wait_for_end`, `format`, `volume` など
+  - レスポンスの補助情報: `Playback Mode`, `Streaming Synthesis`, `Streaming Playback`
+- 履歴系: `list_tts_history`, `get_tts_history`, `play_tts_history`, `delete_tts_history`, `get_tts_history_stats`
+  - `play_tts_history`: 既存ファイルをそのまま OS プレイヤーで再生
+
+## 再生ポリシー（共通の考え方）
+
+- 再生モード: `immediate`（既存停止）/ `queue`（順次）/ `no_queue`（並列）
+- ストリーミング再生: ffplay（Win/Linux）や afplay（macOS）が使えると低遅延。「Streaming Playback: true」で確認
+- 履歴: 合成時に自動保存。履歴からの再生は「既存ファイルをそのまま再生」
+- 既定: デフォルト音声フォーマットは `mp3`
+
+## 基本的な使い方（詳細）
 
 ### 音声合成（TTS）
 
@@ -502,7 +559,7 @@ update_mcp_settings({
 
 </details>
 
-## 再生モードと動作の詳細
+## 再生ポリシー（詳説）
 
 - **immediate**: 現在の再生を停止し、即座に新規音声を再生（キューもクリア）
 - **queue**: 現在の再生を維持し、キューに追加して順次再生（`wait_for_end=true` で完了待機）
@@ -512,7 +569,7 @@ update_mcp_settings({
 - MCP/stdio 実行時は子プロセスの標準出力を抑止し、標準エラーにログを出力します（プロトコル保護）
 - `AIVIS_KEEP_PLAYBACK_FILES=1` で再生用の一時ファイルを削除せず残せます（デバッグ用途）
 
-## ストリーミング再生とプログレッシブ再生のポリシー
+### ストリーミング/プログレッシブ
 
 - ffplay が利用可能な環境では、標準入力（stdin）ストリーミング再生を優先します
   - 例: `ffplay -loglevel error -nodisp -autoexit -volume <0-100> -i -`
@@ -530,8 +587,12 @@ update_mcp_settings({
 
 ffplay は FFmpeg に同梱される小型プレイヤーで、標準入力からの再生に対応します。導入済みの環境では、低遅延で安定したストリーミング再生を自動的に使用します。
 
-- 推奨: Windows では導入を推奨（未導入時は生成完了後の再生にフォールバック）
-- 必須事項: `ffplay` に PATH が通っている必要があります。導入後はターミナル（やアプリ）を再起動して PATH を反映してください。
+- 導入は簡単: 各OSでワンライナーのセットアップ（下記手順）
+- 推奨: Windows では導入を強く推奨（未導入時は生成完了後の再生にフォールバック）
+- 必須事項: `ffplay` に PATH が通っている必要があります（導入後に端末/アプリ再起動）
+- 導入確認は2通り:
+  - `ffplay -version` が表示される
+  - MCPの再生レスポンスに `Streaming Playback: true` が出る（低遅延ストリーミング有効の目印）
 
 <details>
 <summary>FFplay の導入手順と PATH 反映</summary>
@@ -569,6 +630,18 @@ ffplay -version
 
 </details>
 
+### MCPでの再生方式の確認
+
+MCPの TTS ツール（例: `synthesize_speech`, `play_text`, `play_tts_history`）のレスポンスには、以下の行が含まれます。
+
+```
+Streaming Synthesis: true
+Streaming Playback: true
+```
+
+- `Streaming Playback: true` の場合、低遅延のストリーミング再生が有効です（Windows/Linux では ffplay、macOS では afplay 利用など）。
+- Windows で `false` の場合は ffplay 未導入の可能性があります。FFplay を導入すると `true` になります。
+
 ## 対応プラットフォーム
 
 以下のプラットフォーム用のバイナリが含まれています：
@@ -585,6 +658,17 @@ ffplay -version
 
 - デフォルト: `~/.aivis-cli.yaml`
 - カスタム: `--config` フラグで指定
+
+### よく使う設定（抜粋）
+
+| 設定名                  | 目的                                  | 例                                  |
+| ----------------------- | ------------------------------------- | ----------------------------------- |
+| `api_key`               | APIキーの設定                         | `aivis-cloud-cli config set api_key ...` |
+| `default_model_uuid`    | 既定の音声モデル                      | `... config set default_model_uuid ...` |
+| `default_format`        | 既定の音声フォーマット                | `mp3`（推奨）                        |
+| `default_playback_mode` | 既定の再生モード                      | `immediate` / `queue` / `no_queue`  |
+| `history_store_path`    | 履歴の保存ディレクトリ                | `~/.aivis-cli/history/`             |
+| `log_level`             | ログレベル                            | `INFO` / `DEBUG` など               |
 
 <details>
 <summary>利用可能なパラメータ一覧（クリックで展開）</summary>
@@ -614,6 +698,8 @@ ffplay -version
 | `log_level`                | string  | `INFO`                          | ログレベル（DEBUG, INFO, WARN, ERROR）     |
 | `log_output`               | string  | `stdout`                        | ログ出力先（stdout, stderr, ファイルパス） |
 | `log_format`               | string  | `text`                          | ログ形式（text, json）                     |
+
+</details>
 
 ### 設定の優先度
 
@@ -653,7 +739,8 @@ npx @kajidog/aivis-cloud-cli mcp --transport http
 
 これにより、Claude Desktop や他の MCP クライアントとの通信が正常に行われます。
 
-#### 設定例
+<details>
+<summary>設定例（クリックで展開）</summary>
 
 ```yaml
 api_key: "your-api-key"
@@ -680,6 +767,8 @@ log_level: "INFO"
 log_output: "stdout"
 log_format: "text"
 ```
+
+</details>
 
 ## 環境変数
 


### PR DESCRIPTION
Switch the default audio format from WAV to MP3 across the CLI and client configurations. Update the MCP responses to include authoritative playback characteristics, ensuring accurate streaming playback detection based on client-computed values. Adjust documentation to reflect these changes.